### PR TITLE
[IA] hotfix: Changed absolute path in ConsumptionReportTests and adde…

### DIFF
--- a/IntegrationAdapters/IntegrationAdapters/Dtos/ConfigurationDto.cs
+++ b/IntegrationAdapters/IntegrationAdapters/Dtos/ConfigurationDto.cs
@@ -1,11 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace IntegrationAdapters.Dtos
+﻿namespace IntegrationAdapters.Dtos
 {
     public class ConfigurationDto
     {
@@ -17,8 +10,5 @@ namespace IntegrationAdapters.Dtos
         {
             return instance;
         }
-
-
-
     }
 }

--- a/IntegrationAdapters/IntegrationAdapters/Dtos/ConfigurationDto.cs
+++ b/IntegrationAdapters/IntegrationAdapters/Dtos/ConfigurationDto.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IntegrationAdapters.Dtos
+{
+    public class ConfigurationDto
+    {
+        public string myDbConnectionString { get; set; }
+
+        private static ConfigurationDto instance = new ConfigurationDto();
+
+        public static ConfigurationDto GetInstance()
+        {
+            return instance;
+        }
+
+
+
+    }
+}

--- a/IntegrationAdapters/IntegrationAdapters/Services/RabbitMqService/RabbitMqActionBenefitService.cs
+++ b/IntegrationAdapters/IntegrationAdapters/Services/RabbitMqService/RabbitMqActionBenefitService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using IntegrationAdapters.Repositories.DbContexts;
+using IntegrationAdapters.Dtos;
 
 namespace Health_Clinic_Integration.Services.RabbitMqService
 {
@@ -51,7 +52,7 @@ namespace Health_Clinic_Integration.Services.RabbitMqService
 
             DbContextOptionsBuilder<MyDbContext> builder = new DbContextOptionsBuilder<MyDbContext>();
 
-            builder.UseMySql("server=localhost;port=3306;database=newmydb;user=root;password=1337")
+            builder.UseMySql(ConfigurationDto.GetInstance().myDbConnectionString)
                     .UseInternalServiceProvider(serviceProvider);
 
             _context = new MyDbContext(builder.Options);

--- a/IntegrationAdapters/IntegrationAdapters/Startup.cs
+++ b/IntegrationAdapters/IntegrationAdapters/Startup.cs
@@ -1,3 +1,4 @@
+using IntegrationAdapters.Dtos;
 using IntegrationAdapters.Repositories.DbContexts;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -24,6 +25,8 @@ namespace IntegrationAdapters
             services.AddDbContext<MyDbContext>(options =>
             options.UseMySql(ConfigurationExtensions.GetConnectionString(Configuration, "MyDbContextConnectionString")).UseLazyLoadingProxies());
 
+            ConfigurationDto instance = ConfigurationDto.GetInstance();
+            instance.myDbConnectionString = Configuration.GetConnectionString("MyDbContextConnectionString");
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/IntegrationAdapters/IntegrationAdapters/ftpsettings.json
+++ b/IntegrationAdapters/IntegrationAdapters/ftpsettings.json
@@ -1,7 +1,7 @@
 {
-    "SourceFolder": "C:\\Users\\Mark\\Desktop\\org5\\HealthCare-Clinic\\IntegrationAdapters\\IntegrationAdapters",
-    "ServerFolder": "C:\\Users\\Mark\\Desktop\\rebex\\data",
-    "Ip": "192.168.86.1",
-    "Username": "tester",
-    "Password": "password"
+  "SourceFolder": "C:\\Users\\Nikola\\Desktop\\sprint3-petak\\HealthCare-Clinic\\IntegrationAdapters\\IntegrationAdapters",
+  "ServerFolder": "C:\\Users\\Nikola\\Desktop\\Rebex\\data",
+  "Ip": "192.168.56.1",
+  "Username": "tester",
+  "Password": "password"
 }

--- a/IntegrationAdapters/IntegrationAdaptersTests/UnitTests/ConsumptionReportTests.cs
+++ b/IntegrationAdapters/IntegrationAdaptersTests/UnitTests/ConsumptionReportTests.cs
@@ -16,7 +16,7 @@ namespace IntegrationAdaptersTests.UnitTests
         {
             Mock<IConsumptionReport> consReport = new Mock<IConsumptionReport>();
 
-            consReport.Setup(t => t.UploadFileToServer()).Returns(ServerCredentialsDto.GetInstance().ServerFolder + Path.DirectorySeparatorChar + "abc.txt");
+            consReport.Setup(t => t.UploadFileToServer()).Returns("ftpsettings.json");
 
             ReportServiceTest repServTest = new ReportServiceTest();
             repServTest.UploadFileAndCheckIfItExists(consReport.Object).ShouldBe(true);

--- a/IntegrationAdapters/IntegrationAdaptersTests/UnitTests/ConsumptionReportTests.cs
+++ b/IntegrationAdapters/IntegrationAdaptersTests/UnitTests/ConsumptionReportTests.cs
@@ -1,18 +1,22 @@
-﻿using IntegrationAdapters.Services.TestServices;
+﻿using IntegrationAdapters.Dtos;
+using IntegrationAdapters.Services.TestServices;
 using Moq;
 using Shouldly;
+using System.IO;
 using Xunit;
 
 namespace IntegrationAdaptersTests.UnitTests
 {
     public class ConsumptionReportTests
     {
+        // This ftp test is very hard to run in production, simply because in production we are not even meant to use FTP
+
         [Fact]
         public void Upload_Consumption_Report_Successfully()
         {
             Mock<IConsumptionReport> consReport = new Mock<IConsumptionReport>();
 
-            consReport.Setup(t => t.UploadFileToServer()).Returns(@"C:\Users\DANILO\Desktop\REBEX\data\publicXYZ\abc.txt");
+            consReport.Setup(t => t.UploadFileToServer()).Returns(ServerCredentialsDto.GetInstance().ServerFolder + Path.DirectorySeparatorChar + "abc.txt");
 
             ReportServiceTest repServTest = new ReportServiceTest();
             repServTest.UploadFileAndCheckIfItExists(consReport.Object).ShouldBe(true);
@@ -23,7 +27,7 @@ namespace IntegrationAdaptersTests.UnitTests
         {
             Mock<IConsumptionReport> consReport = new Mock<IConsumptionReport>();
 
-            consReport.Setup(t => t.UploadFileToServer()).Returns(@"C:\Users\DANILO\Desktop\REBEX\data\publicXYZ\abcddd.txt");
+            consReport.Setup(t => t.UploadFileToServer()).Returns(ServerCredentialsDto.GetInstance().ServerFolder + Path.DirectorySeparatorChar + "abcddd.txt");
 
             ReportServiceTest repServTest = new ReportServiceTest();
             repServTest.UploadFileAndCheckIfItExists(consReport.Object).ShouldBe(false);


### PR DESCRIPTION
…d Dto for Configuration parameters-hid db connection credentials

-The ftp tests are very hard to run in production, simply because in production we are not even meant to use FTP.
-There is a configuration file called ftpsettings.json, where the FTP usage credentials are